### PR TITLE
Handle false positives in test_remove_virtual_ip

### DIFF
--- a/hawk_test_driver.py
+++ b/hawk_test_driver.py
@@ -596,8 +596,7 @@ class HawkTestDriver:
     def test_remove_virtual_ip(self):
         print("TEST: test_remove_virtual_ip: Remove virtual IP")
         self.click_if_major_version("15", 'configuration')
-        self.remove_rsc("vip")
-        return True
+        return self.remove_rsc("vip")
 
     def test_fencing(self):
         print("TEST: test_fencing")


### PR DESCRIPTION
Current code for `test_remove_virtual_ip` returns True even if it fails to remove the virtual IP address via hawk, as it is not checking the return status of `self.remove_rsc`. This PR fixes this issue.