### PR TITLE
Reset connection address to one of the cluster nodes ...

### DIFF
--- a/hawk_test_driver.py
+++ b/hawk_test_driver.py
@@ -587,9 +587,12 @@ class HawkTestDriver:
         try:
             self._do_login()
         except WebDriverException:
-            print("ERROR: Error while adding virtual IP")
+            print("ERROR: Could not connect to virtual IP")
+            # Reset address to old_addr so remaining tests can connect to HAWK
+            self.addr = old_addr
             return False
         print("INFO: Successfully added virtual IP")
+        # Reset address to old_addr
         self.addr = old_addr
         return True
 


### PR DESCRIPTION
... after testing that the added Virtual IP is working.

Currently, after `test_add_virtual_ip` has added a Virtual IP to the cluster, test script will connect to HAWK via the Virtual IP to verify that the address was successfully configured in the cluster. On success, test script will reset the connection address to the one originally supplied in the -H/--host option; however, if connection to HAWK via the Virtual IP is not possible, connection address is not reset and all remaining tests will fail to connect to HAWK.

This commit resets the connection address even on failures, and also rewords the error message to make it more clear.